### PR TITLE
Fixed bug introduced splitting the switch function

### DIFF
--- a/Domoticz.py
+++ b/Domoticz.py
@@ -34,6 +34,9 @@ class Domoticz:
         f = urllib.request.urlopen(self.url + "/json.htm?type=devices&filter=all&used=true")
         response = f.read()
         payload = json.loads(response.decode('utf-8'))
+        idx = False
+        stype = False
+        dlevel = False
         while i < len(payload['result']):
             if whr.search(payload['result'][i]['Name']) and wht.search(payload['result'][i]['Name']):
                 stype = payload['result'][i]['Type']

--- a/settings.json
+++ b/settings.json
@@ -1,1 +1,1 @@
-{"protocol": false, "authorization": false, "httpport": 80, "label1": "null", "label2": "null", "Devices": "", "password": "", "httpsport": 443, "port": "80", "hostname": "127.0.0.1", "__mycroft_skill_firstrun": false, "username": ""}
+{"protocol": false, "httpsport": 443, "hostname": "127.0.0.1", "Devices": "", "label1": "null", "__mycroft_skill_firstrun": false, "password": "", "port": "80", "authorization": false, "username": "", "httpport": 80, "label2": "null"}


### PR DESCRIPTION
A small bug was introduced when I split the switch function into three. That caused an error when trying to operate a switch that doesn't exist on your system. This fixes it.